### PR TITLE
add support for python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ keywords = ["load testing", "performance", "locust", "grasshopper"]
 license = {file = "LICENSE"}
 requires-python = ">=3.9,<4"
 dependencies = [
-    "gevent ~=21.12.0",
+    "gevent ~=22.10.2",
     "influxdb ~= 5.3.1",
     "locust ~= 2.12.2",
     "locust-influxdb-listener ~= 0.0.9",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 assertpy==1.0
 black==22.1.0
 bump2version==1.0.1
-click==8.0.4
+click==8.1.3
 coverage==6.3.2
 flake8==6.0.0
 flake8-import-order==0.18.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 assertpy==1.0
-black==22.1.0
+black==22.3.0
 bump2version==1.0.1
 click==8.1.3
 coverage==6.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gevent==21.12.0
+gevent==22.10.2
 influxdb==5.3.1
 locust==2.12.2
 locust-influxdb-listener==0.0.9


### PR DESCRIPTION
This PR adds support for Python 3.11. This required a few package upgrades. Verified that this still works with older python versions. 