### PR TITLE
stages shapes QOL improvements

### DIFF
--- a/src/grasshopper/lib/grasshopper.py
+++ b/src/grasshopper/lib/grasshopper.py
@@ -171,9 +171,7 @@ class Grasshopper:
         import grasshopper.lib.util.shapes as shapes
 
         if shape_name in dir(shapes):
-            shape_object = getattr(shapes, shape_name)(**kwargs)
-            kwargs["runtime"] = shape_object._configured_runtime
-            return shape_object
+            return getattr(shapes, shape_name)(**kwargs)
         else:
             raise ValueError(
                 f"Shape {shape_name} does not exist in "

--- a/src/grasshopper/lib/grasshopper.py
+++ b/src/grasshopper/lib/grasshopper.py
@@ -145,6 +145,7 @@ class Grasshopper:
         # env.shape_class is actually supplied a shape *instance*
         # despite the attr name
         env.shape_class = kwargs.get("shape_instance")
+        kwargs["runtime"] = env.shape_class.configured_runtime
 
         # assign the weights to the individual user classes __after__ the shape has been
         # processed because eventually, we will need to consult the shape to get the max
@@ -170,7 +171,9 @@ class Grasshopper:
         import grasshopper.lib.util.shapes as shapes
 
         if shape_name in dir(shapes):
-            return getattr(shapes, shape_name)(**kwargs)
+            shape_object = getattr(shapes, shape_name)(**kwargs)
+            kwargs["runtime"] = shape_object._configured_runtime
+            return shape_object
         else:
             raise ValueError(
                 f"Shape {shape_name} does not exist in "


### PR DESCRIPTION
This PR introduces feature of YAML-defined custom stages. This also changes how duration is interpreted slightly, to make the stages more intuitive. E.g, before, stage durations were defined like this in order to get a bunch of 60 second stages:

```
stages = [
        {"duration": 60, "users": 1, "spawn_rate": 1},
        {"duration": 120, "users": 2, "spawn_rate": 2},
        {"duration": 240, "users": 3, "spawn_rate": 3},
        {"duration": 300, "users": 4, "spawn_rate": 4},
        {"duration": 360, "users": 3, "spawn_rate": 1},
        {"duration": 420, "users": 1, "spawn_rate": 1},
    ]
```

Now, its:

```
stages = [
        {"duration": 60, "users": 1, "spawn_rate": 1},
        {"duration": 60, "users": 2, "spawn_rate": 2},
        {"duration": 60, "users": 3, "spawn_rate": 3},
        {"duration": 60, "users": 4, "spawn_rate": 4},
        {"duration": 60, "users": 3, "spawn_rate": 1},
        {"duration": 60, "users": 1, "spawn_rate": 1},
    ]
```
    