### PR TITLE
Fix: Fix issues around incorrect tags not being sent to Grafana + Add ruff format to repo

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -15,6 +15,7 @@ jobs:
           python-version: "3.10"
       - run: pip install -e ".[dev]"
       - run: ruff check .
+      - run: ruff format --check .
   unit-test:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     needs: [ruff-lint]

--- a/src/grasshopper/lib/journeys/base_journey.py
+++ b/src/grasshopper/lib/journeys/base_journey.py
@@ -53,9 +53,6 @@ class BaseJourney(HttpUser):
     def update_tags(self, new_tags: dict):
         """Update the tags for the influxdb listener."""
         self.tags.update(new_tags)
-        db_listener = self.environment.grasshopper_listeners.influxdb_listener
-        if db_listener is not None:
-            db_listener.additional_tags.update(new_tags)
 
     @classmethod
     def reset_class_attributes(cls):

--- a/src/grasshopper/lib/util/utils.py
+++ b/src/grasshopper/lib/util/utils.py
@@ -20,13 +20,8 @@ def custom_trend(trend_name: str, extra_tag_keys=[]):
 
     def calc_time_delta_and_report_metric(func):
         def wrapper(journey_object, *args, **kwargs):
-            tags = {}
             try:
                 environment = journey_object.environment
-                host = environment.host
-                test_parameters = journey_object.scenario_args
-                if hasattr(journey_object.environment, "extra_context"):
-                    tags.update(journey_object.environment.extra_context)
             except AttributeError:
                 raise ReferenceError(
                     "The custom_trend decorator must be placed on a journey function "
@@ -37,20 +32,13 @@ def custom_trend(trend_name: str, extra_tag_keys=[]):
             result = func(journey_object, *args, **kwargs)
             end_time = datetime.now()
             time_delta = end_time - start_time
-            tags.update(
-                {
-                    extra_tag_key: test_parameters.get(extra_tag_key)
-                    for extra_tag_key in extra_tag_keys
-                }
-            )
-            tags["environment"] = host
             environment.events.request.fire(
                 request_type="CUSTOM",
                 name=trend_name,
                 response_time=round(time_delta.total_seconds() * 1000, 3),
                 response_length=0,
                 response=None,
-                context=tags,
+                context=journey_object.tags,
                 exception=None,
             )
             return result


### PR DESCRIPTION
This fixes the tag propogation issues we were seeing in [issue 40](https://github.com/alteryx/locust-grasshopper/issues/40), and also introduces `ruff format --check .` into the quality checks pipeline, which is the request from [issue 41](https://github.com/alteryx/locust-grasshopper/issues/41).