### PR TITLE
Adding an "attributes" option for report portal launches

### DIFF
--- a/src/grasshopper/lib/configuration/gh_configuration.py
+++ b/src/grasshopper/lib/configuration/gh_configuration.py
@@ -296,6 +296,14 @@ class ConfigurationConstants:
             },
             "default": "Grasshopper Performance Test Run | Launch name unknown",
         },
+        "rp_launch_attributes": {
+            "opts": ["--rp_launch_attributes"],
+            "attrs": {
+                "action": "store",
+                "help": "Launch attributes to use when posting to report portal. NYI",
+            },
+            "default": '{"test_type":"load"}',
+        },
     }
 
     # Scenario attrs are typically set per scenario and usually are loaded from the

--- a/src/grasshopper/lib/fixtures/grasshopper_constants.py
+++ b/src/grasshopper/lib/fixtures/grasshopper_constants.py
@@ -29,6 +29,7 @@ class GrasshopperConstants:
         "rp_launch_name",
         "rp_project",
         "rp_endpoint",
+        "rp_launch_attributes"
     ]
     RUNTIME_DEFAULT = 120.0
     USERS_DEFAULT = 1

--- a/src/grasshopper/lib/fixtures/grasshopper_constants.py
+++ b/src/grasshopper/lib/fixtures/grasshopper_constants.py
@@ -29,7 +29,7 @@ class GrasshopperConstants:
         "rp_launch_name",
         "rp_project",
         "rp_endpoint",
-        "rp_launch_attributes"
+        "rp_launch_attributes",
     ]
     RUNTIME_DEFAULT = 120.0
     USERS_DEFAULT = 1

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -54,6 +54,7 @@ def current_global_defaults():
         "report_portal": False,
         "rp_launch_name": "Grasshopper Performance Test Run | Launch name unknown",
         "rp_launch": "Grasshopper Performance Test Run | Launch name unknown",
+        "rp_launch_attributes": '{"test_type":"load"}',
     }
     return defaults
 

--- a/tests/unit/test_grasshopper_configuration_fixtures.py
+++ b/tests/unit/test_grasshopper_configuration_fixtures.py
@@ -28,6 +28,7 @@ def expected_global_defaults():
         "report_portal": False,
         "rp_launch_name": "Grasshopper Performance Test Run | Launch name unknown",
         "rp_launch": "Grasshopper Performance Test Run | Launch name unknown",
+        "rp_launch_attributes": '{"test_type":"load"}',
     }
     return defaults
 


### PR DESCRIPTION
Adding an 'attributes' option for report portal launches so that we can easily filter and find the ones we want.