### PR TITLE
Add SSL Support to InfluxDB Connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ within that YAML file that corresponds to the scenario you wish to run. Defaults
 you must specify a host.
     E.g. `1.1.1.1`. Defaults to None.
 - `--influx_port`: Port for your `influx_host` in the case where it is non-default.
+- `--influx_ssl`: If your influxdb is using SSL, set this to True. Defaults to False.
+- `--influx_verify_ssl`: If your influxdb is using SSL, set this to True. Defaults to 
+    False.
 - `--influx_user`: Username for your `influx_host`, if you have one.
 - `--influx_pwd`: Password for your `influx_host`, if you have one.
 - `--grafana_host`: If your grafana is a separate URL from the influxdb, you can 

--- a/src/grasshopper/lib/configuration/gh_configuration.py
+++ b/src/grasshopper/lib/configuration/gh_configuration.py
@@ -94,6 +94,25 @@ class ConfigurationConstants:
                 "help": "Password to connect to the influx host.",
             },
         },
+        "influx_ssl": {
+            "opts": ["--influx_ssl"],
+            "attrs": {
+                "action": "store",
+                "type": bool,
+                "help": "Enable SSL for InfluxDB connection.",
+            },
+            "typecast": typecast_bool,
+        },
+
+        "influx_verify_ssl": {
+            "opts": ["--influx_verify_ssl"],
+            "attrs": {
+                "action": "store",
+                "type": bool,
+                "help": "Enable SSL certificate verification for InfluxDB connection.",
+            },
+            "typecast": typecast_bool,
+        },
         "grafana_host": {
             "opts": ["--grafana_host"],
             "attrs": {

--- a/src/grasshopper/lib/configuration/gh_configuration.py
+++ b/src/grasshopper/lib/configuration/gh_configuration.py
@@ -102,6 +102,7 @@ class ConfigurationConstants:
                 "help": "Enable SSL for InfluxDB connection.",
             },
             "typecast": typecast_bool,
+            "default": False,
         },
 
         "influx_verify_ssl": {
@@ -112,6 +113,7 @@ class ConfigurationConstants:
                 "help": "Enable SSL certificate verification for InfluxDB connection.",
             },
             "typecast": typecast_bool,
+            "default": False,
         },
         "grafana_host": {
             "opts": ["--grafana_host"],

--- a/src/grasshopper/lib/fixtures/grasshopper_constants.py
+++ b/src/grasshopper/lib/fixtures/grasshopper_constants.py
@@ -17,6 +17,8 @@ class GrasshopperConstants:
         "influx_port",
         "influx_user",
         "influx_pwd",
+        "influx_ssl",
+        "influx_verify_ssl",
         "grafana_host",
         "shape_instance",
         "scenario_delay",

--- a/src/grasshopper/lib/grasshopper.py
+++ b/src/grasshopper/lib/grasshopper.py
@@ -68,17 +68,11 @@ class Grasshopper:
         if pwd:
             configuration["pwd"] = pwd
 
-        configuration["ssl"] = self.to_bool(self.global_configuration.get("influx_ssl", "False"))
-        configuration["verify_ssl"] = self.to_bool(self.global_configuration.get("influx_verify_ssl", "False"))
+        configuration["ssl"] = self.global_configuration.get("influx_ssl", False)
+
+        configuration["verify_ssl"] = self.global_configuration.get("influx_verify_ssl", False)
 
         return configuration
-
-    @staticmethod
-    def to_bool(value: Union[str, bool]) -> bool:
-        """Convert a string to a boolean."""
-        if isinstance(value, bool):
-            return value
-        return str(value).lower() in ["true", "1", "t"]
 
     @property
     def grafana_configuration(self) -> dict[str, Optional[str]]:

--- a/src/grasshopper/lib/grasshopper.py
+++ b/src/grasshopper/lib/grasshopper.py
@@ -40,7 +40,8 @@ class Grasshopper:
         logger.info("--- /Grasshopper configuration ---")
 
     @property
-    def influx_configuration(self) -> dict[str, Optional[str]]:
+    def influx_configuration(self) -> dict[str, Optional[Union[bool, str]]]:
+
         """Extract the influx related configuration items.
 
         The InfluxDbSettings object should only get keys if there is a
@@ -67,7 +68,17 @@ class Grasshopper:
         if pwd:
             configuration["pwd"] = pwd
 
+        configuration["ssl"] = self.to_bool(self.global_configuration.get("influx_ssl", "False"))
+        configuration["verify_ssl"] = self.to_bool(self.global_configuration.get("influx_verify_ssl", "False"))
+
         return configuration
+
+    @staticmethod
+    def to_bool(value: Union[str, bool]) -> bool:
+        """Convert a string to a boolean."""
+        if isinstance(value, bool):
+            return value
+        return str(value).lower() in ["true", "1", "t"]
 
     @property
     def grafana_configuration(self) -> dict[str, Optional[str]]:


### PR DESCRIPTION
This pull request adds support for secure SSL connections to InfluxDB. With SSL, data transmitted to InfluxDB will be encrypted, enhancing security and protecting metrics and data in transit.

This change will unblock users who need to connect to SSL-enabled InfluxDB instances, which currently fail with an error similar to the one mentioned below:

```bash
 InsecureRequestWarning: Unverified HTTPS request is being made to host. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
---------------------------------------------------------------------------
InfluxDBClientError                       Traceback (most recent call last)

...
...

File [~/Documents/code/scripts/.venv/lib/python3.11/site-packages/influxdb/client.py:413]
in InfluxDBClient.write(self, data, params, expected_response_code, protocol)
    410         data = [data]
    411     data = ('\n'.join(data) + '\n').encode('utf-8')
--> 413 self.request(
    414     url="write",
    415     method='POST',
    416     params=params,
    417     data=data,
    418     expected_response_code=expected_response_code,
    419     headers=headers
    420 )
    421 return True

File [~/Documents/code/scripts/.venv/lib/python3.11/site-packages/influxdb/client.py:378]
in InfluxDBClient.request(self, url, method, params, data, stream, expected_response_code, headers)
    376 else:
    377     err_msg = reformat_error(response)
--> 378     raise InfluxDBClientError(err_msg, response.status_code)

InfluxDBClientError: 405: Method Not Allowed
```