### PR TITLE
change quality checks to run on PRs along with pushes

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -1,6 +1,8 @@
 name: quality checks
 
-on: push
+on: 
+  push:
+  pull_request:
 
 jobs:
   ruff-lint:

--- a/src/grasshopper/lib/configuration/gh_configuration.py
+++ b/src/grasshopper/lib/configuration/gh_configuration.py
@@ -104,7 +104,6 @@ class ConfigurationConstants:
             "typecast": typecast_bool,
             "default": False,
         },
-
         "influx_verify_ssl": {
             "opts": ["--influx_verify_ssl"],
             "attrs": {

--- a/src/grasshopper/lib/grasshopper.py
+++ b/src/grasshopper/lib/grasshopper.py
@@ -41,7 +41,6 @@ class Grasshopper:
 
     @property
     def influx_configuration(self) -> dict[str, Optional[Union[bool, str]]]:
-
         """Extract the influx related configuration items.
 
         The InfluxDbSettings object should only get keys if there is a
@@ -70,7 +69,9 @@ class Grasshopper:
 
         configuration["ssl"] = self.global_configuration.get("influx_ssl", False)
 
-        configuration["verify_ssl"] = self.global_configuration.get("influx_verify_ssl", False)
+        configuration["verify_ssl"] = self.global_configuration.get(
+            "influx_verify_ssl", False
+        )
 
         return configuration
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -51,6 +51,8 @@ def current_global_defaults():
         "cleanup_s3": True,
         "slack": False,
         "influx": False,
+        "influx_ssl": False,
+        "influx_verify_ssl": False,
         "report_portal": False,
         "rp_launch_name": "Grasshopper Performance Test Run | Launch name unknown",
         "rp_launch": "Grasshopper Performance Test Run | Launch name unknown",

--- a/tests/unit/test_grasshopper_configuration_fixtures.py
+++ b/tests/unit/test_grasshopper_configuration_fixtures.py
@@ -25,6 +25,8 @@ def expected_global_defaults():
         "cleanup_s3": True,
         "slack": False,
         "influx": False,
+        "influx_ssl": False,
+        "influx_verify_ssl": False,
         "report_portal": False,
         "rp_launch_name": "Grasshopper Performance Test Run | Launch name unknown",
         "rp_launch": "Grasshopper Performance Test Run | Launch name unknown",


### PR DESCRIPTION
in https://github.com/alteryx/locust-grasshopper/pull/45, @pradippatil noticed that checks were sometimes not running for pull requests. This should fix that issue, along with the bit of unformatted linting that should have been done in the aformentioned PR. 