### PR TITLE
Standardized URL format for targeturl

### DIFF
--- a/src/grasshopper/lib/grasshopper.py
+++ b/src/grasshopper/lib/grasshopper.py
@@ -4,6 +4,7 @@ The Grasshopper class is the main entry point for accessing
 grasshopper functionality.
 
 """
+
 import logging
 import os
 import signal
@@ -35,6 +36,7 @@ class Grasshopper:
         logger.info("--- Grasshopper configuration ---")
 
         for k, v in self.global_configuration.items():
+            v = BaseJourney._normalize_url(v) if k == "target_url" else v
             logger.info(f"{k}: [{v}]")
 
         logger.info("--- /Grasshopper configuration ---")
@@ -156,9 +158,9 @@ class Grasshopper:
         logger.debug(f"Launch received kwargs: {kwargs}")
 
         env = Environment(user_classes=user_classes)
-        kwargs[
-            "user_classes"
-        ] = weighted_user_classes  # pass on the user classes as well
+        kwargs["user_classes"] = (
+            weighted_user_classes  # pass on the user classes as well
+        )
 
         env.grasshopper = Grasshopper(global_configuration=kwargs)
         env.create_local_runner()

--- a/tests/unit/test_base_journey.py
+++ b/tests/unit/test_base_journey.py
@@ -122,3 +122,24 @@ def test_verify_thresholds_collection_shape_invalid_shape(caplog):
         )
     assert not is_valid
     assert "mapping" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "input_url,expected_output",
+    [
+        ("https://test_url.com/", "https://test_url.com"),
+        ("  https://test_url.com/path  ", "https://test_url.com"),
+        ("http://test_url.com/some/path/", "http://test_url.com"),
+        ("https://test_url.com//", "https://test_url.com"),
+        ("https://test_url.com/ ", "https://test_url.com"),
+    ],
+)
+def test_normalize_url_valid(input_url, expected_output):
+    assert BaseJourney._normalize_url(input_url) == expected_output
+
+
+def test_normalize_url_invalid():
+    with pytest.raises(TypeError):
+        BaseJourney._normalize_url(None)
+    with pytest.raises(TypeError):
+        BaseJourney._normalize_url(123)

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -38,12 +38,12 @@ def mock_journey():
 
 
 def check_iteration_count(journey, count):
-    assert (
-        journey.environment.stats.num_iterations == count
-    ), "Decorator did not actually increment the environment iterations count"
-    assert (
-        journey.vu_iteration == count
-    ), "Decorator did not actually increment the vu_iteration count on the journey"
+    assert journey.environment.stats.num_iterations == count, (
+        "Decorator did not actually increment the environment iterations count"
+    )
+    assert journey.vu_iteration == count, (
+        "Decorator did not actually increment the vu_iteration count on the journey"
+    )
 
 
 def test__count_iterations(sample_func, mock_journey):


### PR DESCRIPTION
This MR updates the _normalize_url() method in BaseJourney to ensure consistent formatting of the target_url. Specifically, it:
	•	Strips whitespace and removes all trailing slashes (e.g. https://int.bender.rocks/ → https://int.bender.rocks)
	•	Uses urllib.parse to preserve proper URL structure
	•	Prevents duplicate entries in InfluxDB and Grafana caused by trailing slash variants
	
Closes [TWYX-201](https://alteryx.atlassian.net/browse/TWYX-201)