### PR TITLE
TWYX-201_normalize urls to avoid trailing slash issue

### DIFF
--- a/src/grasshopper/lib/grasshopper.py
+++ b/src/grasshopper/lib/grasshopper.py
@@ -155,9 +155,9 @@ class Grasshopper:
         logger.debug(f"Launch received kwargs: {kwargs}")
 
         env = Environment(user_classes=user_classes)
-        kwargs["user_classes"] = (
-            weighted_user_classes  # pass on the user classes as well
-        )
+        kwargs[
+            "user_classes"
+        ] = weighted_user_classes  # pass on the user classes as well
 
         env.grasshopper = Grasshopper(global_configuration=kwargs)
         env.create_local_runner()

--- a/src/grasshopper/lib/grasshopper.py
+++ b/src/grasshopper/lib/grasshopper.py
@@ -33,6 +33,7 @@ class Grasshopper:
         """Log all the configuration values."""
         logger.info("--- Grasshopper configuration ---")
         for k, v in self.global_configuration.items():
+            v = BaseJourney.normalize_url(v) if k == "target_url" else v
             logger.info(f"{k}: [{v}]")
         logger.info("--- /Grasshopper configuration ---")
 
@@ -154,9 +155,9 @@ class Grasshopper:
         logger.debug(f"Launch received kwargs: {kwargs}")
 
         env = Environment(user_classes=user_classes)
-        kwargs[
-            "user_classes"
-        ] = weighted_user_classes  # pass on the user classes as well
+        kwargs["user_classes"] = (
+            weighted_user_classes  # pass on the user classes as well
+        )
 
         env.grasshopper = Grasshopper(global_configuration=kwargs)
         env.create_local_runner()

--- a/src/grasshopper/lib/journeys/base_journey.py
+++ b/src/grasshopper/lib/journeys/base_journey.py
@@ -66,6 +66,16 @@ class BaseJourney(HttpUser):
     def scenario_args(self):
         return self._test_parameters
 
+    @staticmethod
+    def normalize_url(url: str) -> str:
+        """
+        Strip trailing slashes from the URL.
+        """
+        if not url or not isinstance(url, str):
+            raise TypeError("Expected a non-empty string for URL")
+
+        return url.strip().removesuffix("/")
+
     @classmethod
     def replace_incoming_scenario_args(cls, brand_new_args={}):
         """Replace the existing set of scenario_args with a new collection."""
@@ -121,8 +131,9 @@ class BaseJourney(HttpUser):
 
         self._register_new_vu()
         self._set_thresholds()
-        self.environment.host = self.scenario_args.get("target_url", "") or self.host
-
+        self.environment.host = self.normalize_url(
+            self.scenario_args.get("target_url") or self.host
+        )
         self.tags = {}
         self.defaults["tags"] = self.tags
         self.update_tags({"environment": self.environment.host})

--- a/tests/unit/test_base_journey.py
+++ b/tests/unit/test_base_journey.py
@@ -2,7 +2,6 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
-from grasshopper.lib.fixtures.grasshopper_constants import GrasshopperConstants
 from grasshopper.lib.journeys.base_journey import BaseJourney
 
 
@@ -47,33 +46,132 @@ def test_set_test_parameters_with_thresholds_and_tags():
             "tags": {"foo": "bar"},
         }
     )
+
+
+def test_on_start_raises_type_error_when_no_host_or_target_url():
+    """
+    Test that on_start raises TypeError if neither target_url nor host is set.
+    """
+    BaseJourney.replace_incoming_scenario_args({})
     journey = BaseJourney(MagicMock())
+    journey.environment = MagicMock()
+    journey.environment.host = ""
+    journey.host = ""
+    with pytest.raises(TypeError, match="Expected a non-empty string for URL"):
+        journey.on_start()
+
+
+def test_on_start_uses_host_when_target_url_missing():
+    """
+    Test that on_start uses the class host if target_url is missing.
+    """
+    BaseJourney.replace_incoming_scenario_args({})
+    journey = BaseJourney(MagicMock())
+    journey.environment = MagicMock()
+    journey.host = "http://myhost.com/"
+    journey.environment.host = ""
     journey.on_start()
-    journey._set_thresholds()
-    assert journey.environment.stats.trends["asdf1"] == {
-        "thresholds": [
-            {
-                "less_than_in_ms": 1,
-                "actual_value_in_ms": None,
-                "percentile": GrasshopperConstants.THRESHOLD_PERCENTILE_DEFAULT,
-                "succeeded": None,
-                "http_method": "GET",
-            },
-        ],
-        "tags": {"foo": "bar"},
+    assert journey.environment.host == "http://myhost.com"
+
+
+def test_on_start_uses_target_url_when_present():
+    """
+    Test that on_start uses target_url from scenario_args if present.
+    """
+    BaseJourney.replace_incoming_scenario_args(
+        {"target_url": "http://mytarget_url.com/"}
+    )
+    journey = BaseJourney(MagicMock())
+    journey.environment = MagicMock()
+    journey.host = "http://myhost.com/"
+    journey.environment.host = ""
+    journey.on_start()
+    assert journey.environment.host == "http://mytarget_url.com"
+
+
+def test_update_tags_merges_tags():
+    """
+    Test that update_tags merges new tags into self.tags.
+    """
+    journey = BaseJourney(MagicMock())
+    journey.tags = {"foo": "bar"}
+    journey.update_tags({"baz": "qux"})
+    assert journey.tags == {"foo": "bar", "baz": "qux"}
+
+
+def test_merge_incoming_scenario_args_merges_with_lower_precedence():
+    """
+    Test that merge_incoming_scenario_args merges lower precedence args.
+    """
+    BaseJourney.replace_incoming_scenario_args({"a": 1})
+    BaseJourney.merge_incoming_scenario_args({"a": 0, "b": 2})
+    assert BaseJourney._incoming_test_parameters == {"a": 1, "b": 2}
+
+
+def test_reset_class_attributes_resets_all():
+    """
+    Test that reset_class_attributes resets all class-level attributes.
+    """
+    BaseJourney._incoming_test_parameters = {"foo": "bar"}
+    BaseJourney.defaults = {"thresholds": {"x": 1}, "tags": {"y": 2}}
+    BaseJourney.host = "something"
+    BaseJourney.abstract = False
+    BaseJourney.base_torn_down = True
+    BaseJourney.VUS_DICT = {1: "something"}
+    BaseJourney.reset_class_attributes()
+    assert BaseJourney._incoming_test_parameters == {}
+    assert BaseJourney.defaults == {"thresholds": {}, "tags": {}}
+    assert BaseJourney.host == ""
+    assert BaseJourney.abstract is True
+    assert BaseJourney.base_torn_down is False
+    assert BaseJourney.VUS_DICT == {}
+
+
+def test_get_journey_object_given_vu_number_returns_correct_instance():
+    """
+    Test that get_journey_object_given_vu_number returns the correct journey instance.
+    """
+    BaseJourney.reset_class_attributes()
+    journey = BaseJourney(MagicMock())
+    BaseJourney.VUS_DICT[5] = journey
+    assert BaseJourney.get_journey_object_given_vu_number(5) is journey
+    assert BaseJourney.get_journey_object_given_vu_number(99) is None
+
+
+def test__verify_thresholds_collection_shape_missing_type_and_limit(caplog):
+    journey = BaseJourney(MagicMock())
+    invalid = {"trend": {"percentile": 0.9}}
+    with caplog.at_level(logging.WARNING):
+        assert not journey._verify_thresholds_collection_shape(invalid)
+    assert "must have `type`and `limit` fields defined" in caplog.text
+
+
+def test__verify_thresholds_collection_shape_multiple_invalids(caplog):
+    journey = BaseJourney(MagicMock())
+    invalid = {
+        "trend1": {"type": None, "limit": None},
+        "trend2": {"type": "get", "limit": "not_a_number"},
+        "trend3": {"type": "invalid", "limit": 1},
     }
-    assert journey.environment.stats.trends["asdf2"] == {
-        "thresholds": [
-            {
-                "less_than_in_ms": 2,
-                "actual_value_in_ms": None,
-                "percentile": 0.8,
-                "succeeded": None,
-                "http_method": "POST",
-            },
-        ],
-        "tags": {"foo": "bar"},
-    }
+    with caplog.at_level(logging.WARNING):
+        assert not journey._verify_thresholds_collection_shape(invalid)
+    assert (
+        "must have `type`and `limit` fields defined" in caplog.text
+        or "is invalid. Must be one of" in caplog.text
+        or "Must be numeric" in caplog.text
+    )
+
+
+def test_teardown_sets_base_torn_down_and_clears_vus(monkeypatch):
+    journey = BaseJourney(MagicMock())
+    journey.environment = MagicMock()
+    journey.environment.runner = MagicMock()
+    BaseJourney.VUS_DICT = {1: journey}
+    monkeypatch.setattr("gevent.sleep", lambda x: None)
+    journey.teardown()
+    assert journey.base_torn_down is True
+    assert BaseJourney.VUS_DICT == {}
+    journey.environment.runner.quit.assert_called_once()
 
 
 def test_verify_thresholds_collection_shape_successful():
@@ -126,7 +224,8 @@ def test_verify_thresholds_collection_shape_invalid_shape(caplog):
 
 def test_normalize_url_trailing_slash():
     assert (
-        BaseJourney.normalize_url("http://target_url.com/") == "http://target_url.com"
+        BaseJourney.normalize_url("http://mytarget_url.com/")
+        == "http://mytarget_url.com"
     )
 
 
@@ -140,4 +239,7 @@ def test_normalize_url_raises_type_error_on_non_string():
 
 
 def test_normalize_url_no_trailing_slash():
-    assert BaseJourney.normalize_url("http://target_url.com") == "http://target_url.com"
+    assert (
+        BaseJourney.normalize_url("http://mytarget_url.com")
+        == "http://mytarget_url.com"
+    )

--- a/tests/unit/test_base_journey.py
+++ b/tests/unit/test_base_journey.py
@@ -122,3 +122,22 @@ def test_verify_thresholds_collection_shape_invalid_shape(caplog):
         )
     assert not is_valid
     assert "mapping" in caplog.text
+
+
+def test_normalize_url_trailing_slash():
+    assert (
+        BaseJourney.normalize_url("http://target_url.com/") == "http://target_url.com"
+    )
+
+
+def test_normalize_url_raises_type_error_on_non_string():
+    with pytest.raises(TypeError, match="Expected a non-empty string for URL"):
+        BaseJourney.normalize_url(None)
+    with pytest.raises(TypeError, match="Expected a non-empty string for URL"):
+        BaseJourney.normalize_url(123)
+    with pytest.raises(TypeError, match="Expected a non-empty string for URL"):
+        BaseJourney.normalize_url("")
+
+
+def test_normalize_url_no_trailing_slash():
+    assert BaseJourney.normalize_url("http://target_url.com") == "http://target_url.com"

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -38,12 +38,12 @@ def mock_journey():
 
 
 def check_iteration_count(journey, count):
-    assert (
-        journey.environment.stats.num_iterations == count
-    ), "Decorator did not actually increment the environment iterations count"
-    assert (
-        journey.vu_iteration == count
-    ), "Decorator did not actually increment the vu_iteration count on the journey"
+    assert journey.environment.stats.num_iterations == count, (
+        "Decorator did not actually increment the environment iterations count"
+    )
+    assert journey.vu_iteration == count, (
+        "Decorator did not actually increment the vu_iteration count on the journey"
+    )
 
 
 def test__count_iterations(sample_func, mock_journey):

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -38,12 +38,12 @@ def mock_journey():
 
 
 def check_iteration_count(journey, count):
-    assert journey.environment.stats.num_iterations == count, (
-        "Decorator did not actually increment the environment iterations count"
-    )
-    assert journey.vu_iteration == count, (
-        "Decorator did not actually increment the vu_iteration count on the journey"
-    )
+    assert (
+        journey.environment.stats.num_iterations == count
+    ), "Decorator did not actually increment the environment iterations count"
+    assert (
+        journey.vu_iteration == count
+    ), "Decorator did not actually increment the vu_iteration count on the journey"
 
 
 def test__count_iterations(sample_func, mock_journey):


### PR DESCRIPTION
This MR updates the _normalize_url() method in BaseJourney to ensure consistent formatting of the target_url. Specifically, it:
• Removes all trailing slashes (e.g. https://int.bender.rocks/ → https://int.bender.rocks/)
• Prevents duplicate entries in InfluxDB and Grafana caused by trailing slash variants

Closes [TWYX-201](https://alteryx.atlassian.net/browse/TWYX-201)