### PR TITLE
Imporving logic and logging for adjustment of limit of open files

### DIFF
--- a/src/grasshopper/lib/grasshopper.py
+++ b/src/grasshopper/lib/grasshopper.py
@@ -326,47 +326,48 @@ class Grasshopper:
         """Increase the maximum number of open files allowed."""
         # Adapted from locust source code, main function in locust.main.
         if os.name == "posix":
-            minimum_open_file_limit = 10000
+            minimum_hard_open_file_limit = 10000
+            minimum_soft_open_file_limit = 10000
             try:
                 initial_soft, initial_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
                 logger.info(
-                    f"Current open file limits - soft: {initial_soft}, hard: {initial_hard}"
+                    f"Current open files limits - soft: {initial_soft}, hard: {initial_hard}"
                 )
 
-                if initial_hard < minimum_open_file_limit:
+                if initial_hard < minimum_hard_open_file_limit:
                     try:
                         resource.setrlimit(
                             resource.RLIMIT_NOFILE,
-                            (initial_soft, minimum_open_file_limit),
+                            (initial_soft, minimum_hard_open_file_limit),
                         )
                         _, increased_hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
-                        logger.info(f"Successfully increased hard limit to {increased_hard_limit}")
+                        logger.info(f"Open files hard limit increased to {increased_hard_limit}")
                     except Exception as e:
-                        logger.info(f"Could not increase hard limit directly: {e}")
+                        logger.warning(f"Could not increase hard limit directly: {e}")
                 else:
-                    logger.info(f"Hard limit of {initial_hard} is above minimum required limit of {minimum_open_file_limit}")
+                    logger.info(f"Hard limit of {initial_hard} is in line with minimum required limit of {minimum_hard_open_file_limit}")
 
                 # Try to increase the soft limit separately
                 current_soft_limit, current_hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
-                if current_soft_limit < minimum_open_file_limit:
+                if current_soft_limit < minimum_soft_open_file_limit:
                     try:
                         resource.setrlimit(
                             resource.RLIMIT_NOFILE,
-                            (minimum_open_file_limit, current_hard_limit),
+                            (minimum_soft_open_file_limit, current_hard_limit),
                         )
                         increased_hard_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
-                        logger.info(f"Successfully increased soft limit to {increased_hard_limit}")
+                        logger.info(f"Open files soft limit increased to {increased_hard_limit}")
                     except Exception as e:
-                        logger.info(f"Could not increase soft limit directly: {e}")
+                        logger.warning(f"Could not increase soft limit directly: {e}")
                 else:
-                    logger.info(f"Soft limit of {current_soft_limit} is above minimum required limit of {minimum_open_file_limit}")
+                    logger.info(f"Soft limit of {current_soft_limit} is in line with minimum required limit of {minimum_soft_open_file_limit}")
 
                 final_soft, final_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-                logger.info(f"Final open file limits - soft: {final_soft}, hard: {final_hard}")
-                if final_soft < minimum_open_file_limit:
+                logger.info(f"Final open files limits - soft: {final_soft}, hard: {final_hard}")
+                if final_soft < minimum_soft_open_file_limit:
                     logger.warning(
                         f"System open file limit '{final_soft}' is below minimum "
-                        f"setting '{minimum_open_file_limit}'. It's not high enough for load "
+                        f"setting '{minimum_soft_open_file_limit}'. It's not high enough for load "
                         f"testing, and the OS didn't allow locust to increase it by itself. See "
                         f"https://github.com/locustio/locust/wiki/Installation#increasing-maximum-number-of-open-files-limit "
                         f"for more info."

--- a/src/grasshopper/lib/grasshopper.py
+++ b/src/grasshopper/lib/grasshopper.py
@@ -325,23 +325,55 @@ class Grasshopper:
     def set_ulimit():
         """Increase the maximum number of open files allowed."""
         # Adapted from locust source code, main function in locust.main.
-        try:
-            if os.name == "posix":
-                minimum_open_file_limit = 10000
-                current_open_file_limit = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
-                if current_open_file_limit < minimum_open_file_limit:
-                    # Increasing the limit to 10000 within a running process
-                    # should work on at least MacOS. It does not work on all OS:es,
-                    # but we should be no worse off for trying.
-                    resource.setrlimit(
-                        resource.RLIMIT_NOFILE,
-                        [minimum_open_file_limit, resource.RLIM_INFINITY],
+        if os.name == "posix":
+            minimum_open_file_limit = 10000
+            try:
+                initial_soft, initial_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+                logger.info(
+                    f"Current open file limits - soft: {initial_soft}, hard: {initial_hard}"
+                )
+
+                if initial_hard < minimum_open_file_limit:
+                    try:
+                        resource.setrlimit(
+                            resource.RLIMIT_NOFILE,
+                            (initial_soft, minimum_open_file_limit),
+                        )
+                        _, increased_hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+                        logger.info(f"Successfully increased hard limit to {increased_hard_limit}")
+                    except Exception as e:
+                        logger.info(f"Could not increase hard limit directly: {e}")
+                else:
+                    logger.info(f"Hard limit of {initial_hard} is above minimum required limit of {minimum_open_file_limit}")
+
+                # Try to increase the soft limit separately
+                current_soft_limit, current_hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+                if current_soft_limit < minimum_open_file_limit:
+                    try:
+                        resource.setrlimit(
+                            resource.RLIMIT_NOFILE,
+                            (minimum_open_file_limit, current_hard_limit),
+                        )
+                        increased_hard_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+                        logger.info(f"Successfully increased soft limit to {increased_hard_limit}")
+                    except Exception as e:
+                        logger.info(f"Could not increase soft limit directly: {e}")
+                else:
+                    logger.info(f"Soft limit of {current_soft_limit} is above minimum required limit of {minimum_open_file_limit}")
+
+                final_soft, final_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+                logger.info(f"Final open file limits - soft: {final_soft}, hard: {final_hard}")
+                if final_soft < minimum_open_file_limit:
+                    logger.warning(
+                        f"System open file limit '{final_soft}' is below minimum "
+                        f"setting '{minimum_open_file_limit}'. It's not high enough for load "
+                        f"testing, and the OS didn't allow locust to increase it by itself. See "
+                        f"https://github.com/locustio/locust/wiki/Installation#increasing-maximum-number-of-open-files-limit "
+                        f"for more info."
                     )
-        except BaseException:
-            logger.warning(
-                f"""System open file limit '{current_open_file_limit}' is below minimum
-                setting '{minimum_open_file_limit}'. It's not high enough for load
-                testing, and the OS didn't allow locust to increase it by itself. See
-                https://github.com/locustio/locust/wiki/Installation#increasing-maximum-number-of-open-files-limit
-                for more info."""
-            )
+            except BaseException as e:
+                logger.warning(
+                    f"Failed to retrieve system open file limits: {e}. "
+                )
+        else:
+            logger.info("Can't modify open file limits on non-POSIX systems. Skipping ulimit adjustment.")

--- a/tests/unit/test_set_ulimit.py
+++ b/tests/unit/test_set_ulimit.py
@@ -29,9 +29,9 @@ def test_set_ulimit_already_high():
 
         mock_resource.getrlimit.assert_called_with(mock_resource.RLIMIT_NOFILE)
         mock_resource.setrlimit.assert_not_called()
-        mock_logger.info.assert_any_call("Current open file limits - soft: 15000, hard: 20000")
-        mock_logger.info.assert_any_call("Hard limit of 20000 is above minimum required limit of 10000")
-        mock_logger.info.assert_any_call("Soft limit of 15000 is above minimum required limit of 10000")
+        mock_logger.info.assert_any_call("Current open files limits - soft: 15000, hard: 20000")
+        mock_logger.info.assert_any_call("Hard limit of 20000 is in line with minimum required limit of 10000")
+        mock_logger.info.assert_any_call("Soft limit of 15000 is in line with minimum required limit of 10000")
 
 
 def test_set_ulimit_increase_both_success():
@@ -57,15 +57,15 @@ def test_set_ulimit_increase_both_success():
          patch("grasshopper.lib.grasshopper.logger") as mock_logger:
 
         Grasshopper.set_ulimit()
-        mock_logger.info.assert_any_call("Current open file limits - soft: 2000, hard: 5000")
+        mock_logger.info.assert_any_call("Current open files limits - soft: 2000, hard: 5000")
 
         # Successful hard limit increase
         mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (2000, 10000))
-        mock_logger.info.assert_any_call("Successfully increased hard limit to 10000")
+        mock_logger.info.assert_any_call("Open files hard limit increased to 10000")
 
         # Successful soft limit increase
         mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (10000, 10000))
-        mock_logger.info.assert_any_call("Successfully increased soft limit to 10000")
+        mock_logger.info.assert_any_call("Open files soft limit increased to 10000")
 
         mock_logger.warning.assert_not_called()
 
@@ -98,13 +98,13 @@ def test_set_ulimit_hard_fails_soft_success():
 
         # It should try to set hard limit to (2000, 10000) -> fails
         mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (2000, 10000))
-        mock_logger.info.assert_any_call("Could not increase hard limit directly: Not permitted")
+        mock_logger.warning.assert_any_call("Could not increase hard limit directly: Not permitted")
         # It should then try to set soft limit to (10000, 5000) -> succeeds (hard limit should remain original 5000 since it failed to increase)
         mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (10000, 5000))
-        mock_logger.info.assert_any_call("Successfully increased soft limit to 10000")
+        mock_logger.info.assert_any_call("Open files soft limit increased to 10000")
 
 
-        mock_logger.info.assert_any_call("Final open file limits - soft: 10000, hard: 5000")
+        mock_logger.info.assert_any_call("Final open files limits - soft: 10000, hard: 5000")
 
 
 def test_set_ulimit_hard_success_soft_fails():
@@ -136,19 +136,18 @@ def test_set_ulimit_hard_success_soft_fails():
         Grasshopper.set_ulimit()
 
         # Info log before changes
-        mock_logger.info.assert_any_call("Current open file limits - soft: 2000, hard: 5000")
+        mock_logger.info.assert_any_call("Current open files limits - soft: 2000, hard: 5000")
         # Successful hard limit increase
         mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (2000, 10000))
-        mock_logger.info.assert_any_call("Successfully increased hard limit to 10000")
+        mock_logger.info.assert_any_call("Open files hard limit increased to 10000")
 
         # Failed soft limit increase
         mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (10000, 10000))
-        mock_logger.info.assert_any_call("Could not increase soft limit directly: Soft limit adjustment denied")
+        mock_logger.warning.assert_any_call("Could not increase soft limit directly: Soft limit adjustment denied")
 
-        mock_logger.info.assert_any_call("Final open file limits - soft: 2000, hard: 10000")
+        mock_logger.info.assert_any_call("Final open files limits - soft: 2000, hard: 10000")
 
         # Verify warning log
-        mock_logger.warning.assert_called_once()
         assert "System open file limit '2000' is below minimum" in mock_logger.warning.call_args[0][0]
 
 

--- a/tests/unit/test_set_ulimit.py
+++ b/tests/unit/test_set_ulimit.py
@@ -1,0 +1,168 @@
+from unittest.mock import MagicMock, patch
+
+from grasshopper.lib.grasshopper import Grasshopper
+
+
+def test_set_ulimit_non_posix():
+    """Verify that on non-posix systems, set_ulimit is a no-op."""
+    with patch("grasshopper.lib.grasshopper.os.name", "nt"), \
+         patch("grasshopper.lib.grasshopper.logger") as mock_logger:
+        # If it's nt, resource shouldn't be accessed and no posix actions run.
+        Grasshopper.set_ulimit()
+        mock_logger.info.assert_any_call("Can't modify open file limits on non-POSIX systems. Skipping ulimit adjustment.")
+
+
+def test_set_ulimit_already_high():
+    """Verify that when limits are already high, no changes are attempted."""
+    mock_resource = MagicMock()
+    mock_resource.RLIMIT_NOFILE = 8  # or any dummy constant
+    
+    # Simulate high initial limits (already above 10000)
+    limits = [15000, 20000]
+    mock_resource.getrlimit.side_effect = lambda limit_type: tuple(limits)
+
+    with patch("grasshopper.lib.grasshopper.os.name", "posix"), \
+         patch("grasshopper.lib.grasshopper.resource", mock_resource), \
+         patch("grasshopper.lib.grasshopper.logger") as mock_logger:
+
+        Grasshopper.set_ulimit()
+
+        mock_resource.getrlimit.assert_called_with(mock_resource.RLIMIT_NOFILE)
+        mock_resource.setrlimit.assert_not_called()
+        mock_logger.info.assert_any_call("Current open file limits - soft: 15000, hard: 20000")
+        mock_logger.info.assert_any_call("Hard limit of 20000 is above minimum required limit of 10000")
+        mock_logger.info.assert_any_call("Soft limit of 15000 is above minimum required limit of 10000")
+
+
+def test_set_ulimit_increase_both_success():
+    """Verify that both hard and soft limits are increased if both are below minimum."""
+    mock_resource = MagicMock()
+    mock_resource.RLIMIT_NOFILE = 8
+    
+    # State representation of system open file limits [soft, hard]
+    limits = [2000, 5000]
+    
+    def getrlimit_mock(limit_type):
+        return tuple(limits)
+        
+    def setrlimit_mock(limit_type, new_limits):
+        limits[0] = new_limits[0]
+        limits[1] = new_limits[1]
+
+    mock_resource.getrlimit.side_effect = getrlimit_mock
+    mock_resource.setrlimit.side_effect = setrlimit_mock
+
+    with patch("grasshopper.lib.grasshopper.os.name", "posix"), \
+         patch("grasshopper.lib.grasshopper.resource", mock_resource), \
+         patch("grasshopper.lib.grasshopper.logger") as mock_logger:
+
+        Grasshopper.set_ulimit()
+        mock_logger.info.assert_any_call("Current open file limits - soft: 2000, hard: 5000")
+
+        # Successful hard limit increase
+        mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (2000, 10000))
+        mock_logger.info.assert_any_call("Successfully increased hard limit to 10000")
+
+        # Successful soft limit increase
+        mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (10000, 10000))
+        mock_logger.info.assert_any_call("Successfully increased soft limit to 10000")
+
+        mock_logger.warning.assert_not_called()
+
+
+def test_set_ulimit_hard_fails_soft_success():
+    """Verify that if hard limit increase fails, soft limit still attempts to increase up to hard limit."""
+    mock_resource = MagicMock()
+    mock_resource.RLIMIT_NOFILE = 8
+    
+    initial_limits = [2000, 5000]
+    
+    def getrlimit_mock(limit_type):
+        return tuple(initial_limits)
+        
+    def setrlimit_mock(limit_type, new_limits):
+        if new_limits[1] == 10000:  # trying to increase hard limit to 10000
+            raise PermissionError("Not permitted")
+        # Soft limit increase to 5000 should succeed
+        initial_limits[0] = new_limits[0]
+        initial_limits[1] = new_limits[1]
+
+    mock_resource.getrlimit.side_effect = getrlimit_mock
+    mock_resource.setrlimit.side_effect = setrlimit_mock
+
+    with patch("grasshopper.lib.grasshopper.os.name", "posix"), \
+         patch("grasshopper.lib.grasshopper.resource", mock_resource), \
+         patch("grasshopper.lib.grasshopper.logger") as mock_logger:
+
+        Grasshopper.set_ulimit()
+
+        # It should try to set hard limit to (2000, 10000) -> fails
+        mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (2000, 10000))
+        mock_logger.info.assert_any_call("Could not increase hard limit directly: Not permitted")
+        # It should then try to set soft limit to (10000, 5000) -> succeeds (hard limit should remain original 5000 since it failed to increase)
+        mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (10000, 5000))
+        mock_logger.info.assert_any_call("Successfully increased soft limit to 10000")
+
+
+        mock_logger.info.assert_any_call("Final open file limits - soft: 10000, hard: 5000")
+
+
+def test_set_ulimit_hard_success_soft_fails():
+    """Verify that a warning is logged if the hard limit is successfully increased but soft limit fails to increase."""
+    mock_resource = MagicMock()
+    mock_resource.RLIMIT_NOFILE = 8
+    
+    # State tracking of limits [soft, hard]
+    limits = [2000, 5000]
+    
+    def getrlimit_mock(limit_type):
+        return tuple(limits)
+        
+    def setrlimit_mock(limit_type, new_limits):
+        # If trying to set soft limit to 10000, raise exception
+        if new_limits[0] == 10000:
+            raise PermissionError("Soft limit adjustment denied")
+        # Otherwise hard limit succeeds
+        limits[0] = new_limits[0]
+        limits[1] = new_limits[1]
+
+    mock_resource.getrlimit.side_effect = getrlimit_mock
+    mock_resource.setrlimit.side_effect = setrlimit_mock
+
+    with patch("grasshopper.lib.grasshopper.os.name", "posix"), \
+         patch("grasshopper.lib.grasshopper.resource", mock_resource), \
+         patch("grasshopper.lib.grasshopper.logger") as mock_logger:
+
+        Grasshopper.set_ulimit()
+
+        # Info log before changes
+        mock_logger.info.assert_any_call("Current open file limits - soft: 2000, hard: 5000")
+        # Successful hard limit increase
+        mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (2000, 10000))
+        mock_logger.info.assert_any_call("Successfully increased hard limit to 10000")
+
+        # Failed soft limit increase
+        mock_resource.setrlimit.assert_any_call(mock_resource.RLIMIT_NOFILE, (10000, 10000))
+        mock_logger.info.assert_any_call("Could not increase soft limit directly: Soft limit adjustment denied")
+
+        mock_logger.info.assert_any_call("Final open file limits - soft: 2000, hard: 10000")
+
+        # Verify warning log
+        mock_logger.warning.assert_called_once()
+        assert "System open file limit '2000' is below minimum" in mock_logger.warning.call_args[0][0]
+
+
+def test_set_ulimit_outer_exception():
+    """Verify that if getrlimit raises an exception, it is caught and logged gracefully."""
+    mock_resource = MagicMock()
+    mock_resource.RLIMIT_NOFILE = 8
+    mock_resource.getrlimit.side_effect = OSError("System error")
+
+    with patch("grasshopper.lib.grasshopper.os.name", "posix"), \
+         patch("grasshopper.lib.grasshopper.resource", mock_resource), \
+         patch("grasshopper.lib.grasshopper.logger") as mock_logger:
+
+        Grasshopper.set_ulimit()
+
+        mock_logger.warning.assert_called_once()
+        assert "Failed to retrieve system open file limits:" in mock_logger.warning.call_args[0][0]


### PR DESCRIPTION
Added for logs for improve visibility during execution. 
Improved logic so both soft and hard open files limit is increased separately. In some cases increase failed because of hard limit which caused failure also for soft limit. After this change, both should be increased separately which should increase with probability of successful increase.