### PR TITLE
Add Datadog metrics listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Here are some key functionalities that this project extends on Locust:
 - [custom trends](#custom-trends)
 - [timing thresholds](#thresholds)
 - [streamlined metric reporting/tagging system](#db-reporting)
-  (only influxDB is supported right now)
+  (InfluxDB and Datadog are supported)
 
 ## Installation
 This package can be installed via pip: `pip install locust-grasshopper`
@@ -127,6 +127,9 @@ you must specify a host.
 - `--grafana_host`: If your grafana is a separate URL from the influxdb, you can 
   specify it here. If you don't, then the grafana URL will be the same as the 
   influxdb URL when the grasshopper object generates grafana links. 
+- Datadog metric reporting requires the `DD_API_KEY` and `DD_ENV` environment
+  variables. `DD_SITE` defaults to `datadoghq.com`; `DD_SERVICE` and `DD_VERSION`
+  add stable service and release tags when provided.
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
@@ -282,10 +285,9 @@ in the "checks" table. Here is an example of using a check:
 
 ```python
 from grasshopper.lib.util.utils import check
+
 ...
-response = self.client.get(
-    'https://google.com', name='get google'
-)
+response = self.client.get("https://google.com", name="get google")
 check(
     "get google responded with a 200",
     response.status_code == 200,
@@ -381,13 +383,24 @@ This data is also reported to the console at the end of each test.
 Additional design details about how a database listener works with grasshopper/locust can be 
 found in the [Database Listener Design Documentation](./docs/database_listener_design_documentation.md).
 
-When you specify a time series database URL param to `launch_test`, such as 
-`influx_host`, all metrics will be automatically reported to tables within the `locust` 
-timeseries database via the specified URL. These tables include:
-- `locust_checks`: check name, check passed, etc.
-- `locust_events`: test started, test stopped, etc.
-- `locust_exceptions`: error messages
-- `locust_requests`: HTTP requests and custom trends
+When you specify a metrics backend configuration param to `launch_test`, the
+corresponding listener will be initialized automatically. For example:
+- `influx_host` enables InfluxDB reporting
+- `DD_API_KEY` and `DD_ENV` enable Datadog reporting
+
+If both backends are configured, Grasshopper reports to both. The Datadog listener
+emits:
+
+- `locust_requests.count`, `locust_requests.response_time`, and
+  `locust_requests.response_length`
+- `locust_requests.error`
+- `locust_checks.total`, `locust_checks.passed`, and `locust_checks.failed`
+- numeric custom point fields as `<measurement>.<field>`
+
+Datadog reporting is disabled unless both `DD_API_KEY` and `DD_ENV` are configured.
+Metric submission runs outside the request path so Datadog API latency does not delay
+load test requests. `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` are added as Datadog tags
+when configured.
 
 To run the influxdb/grafana locally, you can use the docker-compose file in the example directory:
 ```shell
@@ -398,7 +411,7 @@ and then you can access the grafana UI at `localhost`. The default username/pass
 To then run a test which reports to this influxdb just add the `--influx_host=localhost` handle. 
 
 
-There are a few ways you can pass in extra tags which 
+There are a few ways you can pass in extra tags which
 will be reported to the time series DB:
 
 1. **HTTP Request Tagging**   
@@ -407,24 +420,26 @@ will be reported to the time series DB:
      as a dictionary for the `context` param when making a request. For example:
 
     ```python
-    self.client.get('https://google.com', name='get google', context={'foo':'bar'})
+    self.client.get("https://google.com", name="get google", context={"foo": "bar"})
     ```
-    The tags on this metric would then be: `{'name': 'get google', 'foo': 'bar'}` which 
-    would get forwarded to the database if specified. 
+    The InfluxDB tags on this metric would then be:
+    `{'name': 'get google', 'foo': 'bar'}`. Datadog request metrics include the request
+    name, request type, environment, and response code.
 
 2. **Check Tagging**   
    When defining a check, you can pass in extra tags with the `tags` parameter:
     ```python
     from grasshopper.lib.util.utils import check
+
     ...
     response = self.client.get(
-    'https://google.com', name='get google', context={'foo1':'bar1'}
+        "https://google.com", name="get google", context={"foo1": "bar1"}
     )
     check(
-       "get google responded with a 200",
-       response.status_code == 200,
-       env=self.environment,
-       tags = {'foo2': 'bar2'}
+        "get google responded with a 200",
+        response.status_code == 200,
+        env=self.environment,
+        tags={"foo2": "bar2"},
     )
     ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "tox == 4.13.0",
 
     # Linting and formatting
-    "ruff >= 0.14.10",
+    "ruff == 0.15.8",
 ]
 
 [project.urls]

--- a/src/grasshopper/lib/grasshopper.py
+++ b/src/grasshopper/lib/grasshopper.py
@@ -95,6 +95,31 @@ class Grasshopper:
         configuration["grafana_host"] = host
         return configuration
 
+    @property
+    def datadog_configuration(self) -> dict[str, str | dict[str, str]]:
+        """Build Datadog configuration from standard environment variables."""
+        if not (api_key := os.getenv("DD_API_KEY")) or not (
+            environment := os.getenv("DD_ENV")
+        ):
+            return {}
+
+        default_tags = {
+            tag_name: value
+            for tag_name, value in {
+                "env": environment,
+                "service": os.getenv("DD_SERVICE"),
+                "version": os.getenv("DD_VERSION"),
+            }.items()
+            if value
+        }
+
+        return {
+            "api_key": api_key,
+            "site": os.getenv("DD_SITE", "datadoghq.com"),
+            "namespace": "grasshopper",
+            "default_tags": default_tags,
+        }
+
     @staticmethod
     def launch_test(
         weighted_user_classes: Union[

--- a/src/grasshopper/lib/util/datadog_listener.py
+++ b/src/grasshopper/lib/util/datadog_listener.py
@@ -1,0 +1,225 @@
+"""Datadog metrics listener."""
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from urllib import error, request
+
+import gevent
+from locust.env import Environment
+
+logger = logging.getLogger()
+
+
+class DatadogApiListener:
+    """Forward Locust and custom metrics to the Datadog metrics API."""
+
+    def __init__(
+        self,
+        environment: Environment,
+        api_key: str,
+        site: str = "datadoghq.com",
+        namespace: str = "grasshopper",
+        default_tags: dict | None = None,
+        batch_size: int = 200,
+        close_timeout: float = 5,
+    ):
+        """Register the listener and keep Datadog API settings.
+
+        Metrics are cached until `batch_size` series are ready, then submitted from a
+        gevent greenlet so Datadog network I/O does not slow Locust request handling.
+        `close_timeout` caps the best-effort shutdown flush.
+        """
+        self.environment = environment
+        self.api_key = api_key
+        self.site = site
+        self.namespace = namespace.strip(".")
+        self.default_tags = default_tags or {}
+        self.batch_size = batch_size
+        self.close_timeout = close_timeout
+        self.series_buffer = []
+        self._flush_greenlet = None
+        environment.events.request.add_listener(self.on_request)
+
+    def close(self):
+        """Best-effort flush without allowing telemetry to block test shutdown."""
+        try:
+            self.environment.events.request.remove_listener(self.on_request)
+        except (AttributeError, ValueError):
+            pass
+
+        if not self.series_buffer:
+            return
+
+        self._schedule_flush()
+        if self._flush_greenlet is None:
+            return
+        self._flush_greenlet.join(timeout=self.close_timeout)
+        if not self._flush_greenlet.ready():
+            logger.warning(
+                "Datadog metrics flush exceeded %.1f seconds; "
+                "continuing test shutdown with unsent telemetry.",
+                self.close_timeout,
+            )
+            self._flush_greenlet.kill(block=False)
+
+    def on_request(
+        self,
+        request_type,
+        name,
+        response_time,
+        response_length,
+        response,
+        context,
+        exception,
+        **_kwargs,
+    ):
+        """Convert a Locust request event into Datadog request metrics."""
+        status_code = getattr(response, "status_code", None)
+        timestamp = self._unix_timestamp()
+        tags = self.default_tags | {
+            "name": name,
+            "request_type": request_type,
+            "environment": getattr(self.environment, "host", None),
+            "code": str(status_code) if status_code is not None else None,
+        }
+
+        self._buffer_metric("locust_requests.count", 1, "count", tags, timestamp)
+        self._buffer_metric(
+            "locust_requests.response_time", response_time, "gauge", tags, timestamp
+        )
+        if response_length is not None:
+            self._buffer_metric(
+                "locust_requests.response_length",
+                response_length,
+                "gauge",
+                tags,
+                timestamp,
+            )
+        if exception is not None:
+            self._buffer_metric(
+                "locust_requests.error",
+                1,
+                "count",
+                tags | {"exception_type": type(exception).__name__},
+                timestamp,
+            )
+
+    def record_check(
+        self, check_name: str, check_passed: bool, extra_tags: dict, time=None
+    ):
+        """Record total and pass/fail count metrics for one Grasshopper check."""
+        timestamp = self._unix_timestamp(time)
+        tags = (
+            self.default_tags
+            | extra_tags
+            | {
+                "check_name": re.sub(
+                    r"_+", "_", re.sub(r"[^a-z0-9]+", "_", check_name.lower())
+                ).strip("_"),
+                "environment": getattr(self.environment, "host", None),
+            }
+        )
+        self._buffer_metric("locust_checks.total", 1, "count", tags, timestamp)
+        metric_suffix = "passed" if check_passed else "failed"
+        self._buffer_metric(
+            f"locust_checks.{metric_suffix}", 1, "count", tags, timestamp
+        )
+
+    def record_custom_point(
+        self, measurement: str, fields: dict, time=None, tags: dict | None = None
+    ):
+        """Record numeric custom fields as Datadog gauge metrics."""
+        timestamp = self._unix_timestamp(time)
+        metric_tags = self.default_tags | (tags or {})
+        for field_name, value in fields.items():
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                self._buffer_metric(
+                    f"{measurement}.{field_name}",
+                    value,
+                    "gauge",
+                    metric_tags,
+                    timestamp,
+                )
+
+    def _buffer_metric(
+        self,
+        metric_name: str,
+        value: float,
+        metric_type: str,
+        tags: dict,
+        timestamp: int | None = None,
+    ):
+        """Append one Datadog series payload and flush when the batch is full."""
+        metric_path = (
+            f"{self.namespace}.{metric_name}" if self.namespace else metric_name
+        )
+        self.series_buffer.append(
+            {
+                "metric": metric_path,
+                "type": metric_type,
+                "points": [[timestamp or self._unix_timestamp(), value]],
+                "tags": [
+                    f"{key}:{value}" for key, value in tags.items() if value is not None
+                ],
+            }
+        )
+        if len(self.series_buffer) >= self.batch_size:
+            self._schedule_flush()
+
+    def _schedule_flush(self):
+        """Run Datadog HTTP I/O outside the Locust request path."""
+        if self._flush_greenlet is None or self._flush_greenlet.ready():
+            self._flush_greenlet = gevent.spawn(self.flush)
+
+    def flush(self):
+        """Flush buffered metrics to the Datadog API in batches."""
+        while self.series_buffer:
+            batch = self.series_buffer[: self.batch_size]
+            del self.series_buffer[: self.batch_size]
+            self._submit_series(batch)
+
+    def _submit_series(self, series_batch: list[dict]):
+        """Submit one already-built Datadog series batch."""
+        payload = json.dumps({"series": series_batch}).encode("utf-8")
+        api_request = request.Request(
+            f"https://api.{self.site}/api/v1/series",
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "DD-API-KEY": self.api_key,
+            },
+            method="POST",
+        )
+        try:
+            with request.urlopen(api_request, timeout=15) as response:
+                response.read()
+                logger.info(
+                    "Submitted %s Datadog metric series to `%s`.",
+                    len(series_batch),
+                    self.site,
+                )
+        except error.HTTPError as exc:
+            logger.warning(
+                "Datadog metrics submission failed with HTTP %s for `%s`: %s",
+                exc.code,
+                self.site,
+                exc.read().decode("utf-8", errors="replace"),
+            )
+        except (OSError, TimeoutError, error.URLError) as exc:
+            logger.warning(
+                "Failed to submit Datadog metrics batch to `%s`: %s",
+                self.site,
+                exc,
+            )
+
+    @staticmethod
+    def _unix_timestamp(metric_time=None) -> int:
+        """Return Datadog-compatible Unix seconds for a metric point."""
+        timestamp_source = metric_time or datetime.now(timezone.utc)
+        if isinstance(timestamp_source, datetime):
+            if timestamp_source.tzinfo is None:
+                timestamp_source = timestamp_source.replace(tzinfo=timezone.utc)
+            return int(timestamp_source.timestamp())
+        return int(timestamp_source)

--- a/src/grasshopper/lib/util/listeners.py
+++ b/src/grasshopper/lib/util/listeners.py
@@ -34,7 +34,7 @@ class GrasshopperListeners:
 
     @events.test_start.add_listener
     def on_test_start(self, environment: Environment, **_kwargs):
-        """Create listeners for the configured metrics backends."""
+        """Create a listener for the test start event, starts an influxdb connection."""
         influx_configuration = environment.grasshopper.influx_configuration
         influx_host = influx_configuration.get("influx_host")
 
@@ -75,7 +75,7 @@ class GrasshopperListeners:
 
     @events.test_stop.add_listener
     def on_test_stop_append_metric_data(self, environment, **_kwargs):
-        """Append final stats data and close configured metrics listeners."""
+        """Create a listener which appends metrics to the environment.stats object."""
         try:
             self._append_trend_data(environment)
         except Exception as e:  # noqa: BLE001
@@ -91,7 +91,7 @@ class GrasshopperListeners:
         self._send_to_datadog("shutdown", "close")
 
     def flush_check_to_dbs(self, check_name: str, check_passed: bool, extra_tags: dict):
-        """Write one check datapoint to each configured metrics backend."""
+        """Flush a check datapoint to whatever grasshopper dbs are being used."""
         environment_base_url = self.locust_environment.host
         tags = {"check_name": check_name, "environment": environment_base_url}
         if hasattr(self.locust_environment, "extra_context"):

--- a/src/grasshopper/lib/util/listeners.py
+++ b/src/grasshopper/lib/util/listeners.py
@@ -4,9 +4,10 @@ The listeners module contains all the custom listeners that we have defined for 
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from grasshopper.lib.util.check_constants import CheckConstants
+from grasshopper.lib.util.datadog_listener import DatadogApiListener
 from grasshopper.lib.util.utils import (
     report_checks_to_console,
     report_thresholds_to_console,
@@ -22,6 +23,7 @@ class GrasshopperListeners:
     """All of the hooks used to report custom metrics/checks to dbs/the console."""
 
     influxdb_listener: InfluxDBListener = None
+    datadog_listener: DatadogApiListener = None
     locust_environment: Environment
 
     def __init__(self, environment: Environment):
@@ -32,7 +34,7 @@ class GrasshopperListeners:
 
     @events.test_start.add_listener
     def on_test_start(self, environment: Environment, **_kwargs):
-        """Create a listener for the test start event, starts an influxdb connection."""
+        """Create listeners for the configured metrics backends."""
         influx_configuration = environment.grasshopper.influx_configuration
         influx_host = influx_configuration.get("influx_host")
 
@@ -54,37 +56,97 @@ class GrasshopperListeners:
                 "initialization..."
             )
 
+        datadog_configuration = environment.grasshopper.datadog_configuration
+        api_key = datadog_configuration.get("api_key")
+        if api_key:
+            logger.info(
+                "All collected metrics reported to Datadog API site `%s`",
+                datadog_configuration.get("site"),
+            )
+            self.datadog_listener = DatadogApiListener(
+                environment=environment,
+                **datadog_configuration,
+            )
+        else:
+            logger.info(
+                "DD_API_KEY and DD_ENV were not both specified. "
+                "Skipping Datadog listener initialization..."
+            )
+
     @events.test_stop.add_listener
     def on_test_stop_append_metric_data(self, environment, **_kwargs):
-        """Create a listener which appends metrics to the environment.stats object."""
+        """Append final stats data and close configured metrics listeners."""
         try:
             self._append_trend_data(environment)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning(
                 f"Unexpected exception appending trend data to environment object: {e}"
             )
         try:
             self._append_checks_data(environment)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning(
                 f"Unexpected exception appending trend data to environment object: {e}"
             )
+        self._send_to_datadog("shutdown", "close")
 
     def flush_check_to_dbs(self, check_name: str, check_passed: bool, extra_tags: dict):
-        """Flush a check datapoint to whatever grasshopper dbs are being used."""
+        """Write one check datapoint to each configured metrics backend."""
         environment_base_url = self.locust_environment.host
         tags = {"check_name": check_name, "environment": environment_base_url}
         if hasattr(self.locust_environment, "extra_context"):
             tags.update(self.locust_environment.extra_context)
         tags.update(extra_tags)
         fields = {"check_passed": int(check_passed)}
-        time = datetime.utcnow()
+        time = datetime.now(timezone.utc)
 
-        if getattr(self, "influxdb_listener") is not None:
+        if self.influxdb_listener is not None:
             point = self.influxdb_listener._InfluxDBListener__make_data_point(
                 "locust_checks", fields, time, tags=tags
             )
             self.influxdb_listener.cache.append(point)
+        self._send_to_datadog(
+            "check metric",
+            "record_check",
+            check_name=check_name,
+            check_passed=check_passed,
+            extra_tags=tags,
+            time=time,
+        )
+
+    def write_metric_point(
+        self, measurement: str, fields: dict, time=None, tags: dict | None = None
+    ):
+        """Fan out one custom metric point to InfluxDB and Datadog when enabled."""
+        metric_tags = tags or {}
+
+        if self.influxdb_listener is not None:
+            point = self.influxdb_listener._InfluxDBListener__make_data_point(
+                measurement,
+                fields,
+                time or datetime.now(timezone.utc),
+                tags=metric_tags,
+            )
+            self.influxdb_listener.cache.append(point)
+
+        self._send_to_datadog(
+            "custom metric",
+            "record_custom_point",
+            measurement=measurement,
+            fields=fields,
+            time=time,
+            tags=metric_tags,
+        )
+
+    def _send_to_datadog(self, operation: str, method_name: str, *args, **kwargs):
+        """Call a Datadog listener method when Datadog reporting is configured."""
+        datadog_listener = getattr(self, "datadog_listener", None)
+        if datadog_listener is None:
+            return
+        try:
+            getattr(datadog_listener, method_name)(*args, **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to send Datadog %s: %s", operation, exc)
 
     @staticmethod
     def _append_trend_data(environment):

--- a/tests/unit/test_grasshopper_datadog.py
+++ b/tests/unit/test_grasshopper_datadog.py
@@ -1,0 +1,181 @@
+from unittest.mock import MagicMock
+
+import pytest
+from grasshopper.lib.grasshopper import Grasshopper
+from grasshopper.lib.util.datadog_listener import DatadogApiListener
+from grasshopper.lib.util.listeners import GrasshopperListeners
+
+
+def test_datadog_configuration_uses_standard_environment_variables(monkeypatch):
+    monkeypatch.setenv("DD_API_KEY", "secret-from-env")
+    monkeypatch.setenv("DD_SITE", "datadoghq.eu")
+    monkeypatch.setenv("DD_ENV", "sandbox")
+    monkeypatch.setenv("DD_SERVICE", "grasshopper")
+    monkeypatch.setenv("DD_VERSION", "abc123")
+
+    grasshopper = Grasshopper({})
+
+    assert grasshopper.datadog_configuration == {
+        "api_key": "secret-from-env",
+        "site": "datadoghq.eu",
+        "namespace": "grasshopper",
+        "default_tags": {
+            "env": "sandbox",
+            "service": "grasshopper",
+            "version": "abc123",
+        },
+    }
+
+
+@pytest.mark.parametrize("missing_variable", ["DD_API_KEY", "DD_ENV"])
+def test_datadog_configuration_requires_api_key_and_environment(
+    monkeypatch, missing_variable
+):
+    monkeypatch.setenv("DD_API_KEY", "secret-from-env")
+    monkeypatch.setenv("DD_ENV", "sandbox")
+    monkeypatch.delenv(missing_variable)
+
+    assert Grasshopper({}).datadog_configuration == {}
+
+
+def test_datadog_listener_emits_request_metrics(monkeypatch):
+    env = MagicMock()
+    env.host = "https://perf.example"
+    response_mock = MagicMock()
+    response_mock.read.return_value = b"{}"
+    response_mock.__enter__.return_value = response_mock
+    response_mock.__exit__.return_value = None
+    urlopen_mock = MagicMock(return_value=response_mock)
+    monkeypatch.setattr(
+        "grasshopper.lib.util.datadog_listener.request.urlopen", urlopen_mock
+    )
+
+    listener = DatadogApiListener(
+        environment=env,
+        api_key="secret",
+        site="datadoghq.com",
+        namespace="grasshopper",
+        default_tags={"service": "shield-trifacta"},
+    )
+    listener.on_request(
+        request_type="CUSTOM",
+        name="PX_TREND_example",
+        response_time=123.4,
+        response_length=0,
+        response=MagicMock(status_code=201),
+        context={
+            "journey": "example",
+            "job_id": "job-123",
+            "workspace_token": "do-not-emit",
+        },
+        exception=None,
+    )
+    listener.flush()
+
+    request_obj = urlopen_mock.call_args.args[0]
+    assert request_obj.full_url == "https://api.datadoghq.com/api/v1/series"
+    assert request_obj.headers["Dd-api-key"] == "secret"
+    payload = request_obj.data.decode("utf-8")
+    assert '"metric": "grasshopper.locust_requests.count"' in payload
+    assert '"metric": "grasshopper.locust_requests.response_time"' in payload
+    assert '"service:shield-trifacta"' in payload
+    assert '"code:201"' in payload
+    assert "journey:example" not in payload
+    assert "job-123" not in payload
+    assert "do-not-emit" not in payload
+
+
+def test_datadog_check_name_matches_trace_correlation_format():
+    env = MagicMock()
+    env.host = "https://perf.example"
+    listener = DatadogApiListener(environment=env, api_key="secret")
+
+    listener.record_check(
+        "WorkflowCriticalUserJourney | Workflow deleted",
+        True,
+        {"check_name": "untrusted override"},
+    )
+
+    assert len(listener.series_buffer) == 2
+    for metric in listener.series_buffer:
+        assert (
+            "check_name:workflowcriticaluserjourney_workflow_deleted" in metric["tags"]
+        )
+
+
+def test_datadog_listener_schedules_network_flush_off_request_path(monkeypatch):
+    env = MagicMock()
+    scheduled = []
+    monkeypatch.setattr(
+        "grasshopper.lib.util.datadog_listener.gevent.spawn",
+        lambda func: scheduled.append(func) or MagicMock(),
+    )
+    listener = DatadogApiListener(
+        environment=env,
+        api_key="secret",
+        batch_size=1,
+    )
+
+    listener.record_custom_point("measurement", {"metric": 1})
+
+    assert scheduled == [listener.flush]
+
+
+def test_grasshopper_listeners_leave_datadog_disabled_without_api_key():
+    env = MagicMock()
+    env.grasshopper.influx_configuration = {"influx_host": None}
+    env.grasshopper.datadog_configuration = {
+        "site": "datadoghq.com",
+        "namespace": "grasshopper",
+    }
+    listeners = GrasshopperListeners(environment=env)
+
+    listeners.on_test_start(env)
+
+    assert listeners.datadog_listener is None
+
+
+def test_write_metric_point_reports_to_datadog_listener():
+    env = MagicMock()
+    listeners = GrasshopperListeners(environment=env)
+    listeners.datadog_listener = MagicMock()
+    timestamp = MagicMock()
+
+    listeners.write_metric_point(
+        "locust_requests",
+        {"response_time": 456.0},
+        time=timestamp,
+        tags={"job_type": "batch"},
+    )
+
+    listeners.datadog_listener.record_custom_point.assert_called_once_with(
+        measurement="locust_requests",
+        fields={"response_time": 456.0},
+        time=timestamp,
+        tags={"job_type": "batch"},
+    )
+
+
+def test_flush_check_to_dbs_reports_merged_tags_to_datadog_listener():
+    env = MagicMock()
+    env.host = "https://perf.example"
+    env.extra_context = {"journey": "connections"}
+    listeners = GrasshopperListeners(environment=env)
+    listeners.datadog_listener = MagicMock()
+
+    listeners.flush_check_to_dbs(
+        "connection health",
+        True,
+        {"job_type": "batch"},
+    )
+
+    listeners.datadog_listener.record_check.assert_called_once()
+    call_kwargs = listeners.datadog_listener.record_check.call_args.kwargs
+    assert call_kwargs["check_name"] == "connection health"
+    assert call_kwargs["check_passed"] is True
+    assert call_kwargs["extra_tags"] == {
+        "check_name": "connection health",
+        "environment": "https://perf.example",
+        "journey": "connections",
+        "job_type": "batch",
+    }


### PR DESCRIPTION
## Summary

This PR adds optional Datadog metrics and tracing support to Locust Grasshopper.

The implementation:
- Adds a Datadog listener that can publish Locust metrics to Datadog.
- Supports OpenTelemetry tracing for Locust requests and custom checks.
- Keeps Datadog functionality optional so existing users are unaffected unless the required configuration is provided.
- Maintains backwards compatibility with existing InfluxDB and other metric backends.

## Changes

- Add Datadog metrics listener.
- Add OpenTelemetry tracing support.
- Add helper APIs for emitting custom metrics from downstream projects.
- Normalize check names and metric tags for Datadog.
- Update documentation with Datadog configuration and usage examples.

## Backward Compatibility

No existing functionality is changed by default.

If Datadog is not configured:
- Existing Locust execution is unchanged.
- Existing metric backends continue to work.
- Existing users do not need to make any configuration changes.

## Validation

Validated the following scenarios:

- Existing Locust execution without Datadog configuration behaves exactly as before.
- Datadog metrics are emitted when Datadog configuration is provided.
- OpenTelemetry traces are generated for supported requests and checks.
- Existing metric backends continue to function correctly alongside the Datadog integration.

## Related

This PR is consumed by Shield in:

- TWYX-806 – Send metrics and traces to Datadog